### PR TITLE
feat: allow setting service account name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This module creates all the proper permissions and service accounts so that Full
 |------|-------------|------|---------|:--------:|
 | <a name="input_dataset_id"></a> [dataset\_id](#input\_dataset\_id) | The dataset that Fullstory will use to sync data. | `string` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | The target GCP project that will be used for all resources. | `string` | n/a | yes |
+| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The name of the service account to use with Fullstory | `string` | `"fullstory-bigquery-setup"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 resource "google_service_account" "main" {
-  account_id   = "fullstory-bigquery-setup"
-  display_name = "Fullstory BigQuery Setup"
+  account_id   = var.service_account_name
+  display_name = var.service_account_name
   description  = "Used by Fullstory to load data into BigQuery"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -7,3 +7,9 @@ variable "dataset_id" {
   type        = string
   description = "The dataset that Fullstory will use to sync data."
 }
+
+variable "service_account_name" {
+  type = string
+  description = "The name of the service account to use with Fullstory"
+  default = "fullstory-bigquery-setup"
+}


### PR DESCRIPTION
## Description
Allowing setting this via input variables will allow users to provide a name in cases where there are existing conventions for service accounts.

## Checklist before submitting PR for review

- [x] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [x] I have ensured my code is commented and any new terraform variables have proper descriptions
